### PR TITLE
Fix/Display launch site local time

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -23,7 +23,7 @@ import {
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatLaunchSiteDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -126,7 +126,7 @@ function TimeAndLocation({ launch }) {
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
           <Tooltip label={formatDateTime(launch.launch_date_local)}>
-            {formatDateTime(launch.launch_date_local)}
+            {formatLaunchSiteDateTime(launch.launch_date_local)}
           </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,6 +19,7 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
@@ -124,7 +125,9 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip label={formatDateTime(launch.launch_date_local)}>
+            {formatDateTime(launch.launch_date_local)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,12 @@
+const dateTimeOptions = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+}
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
@@ -9,12 +18,25 @@ export function formatDate(timestamp) {
 
 export function formatDateTime(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-    timeZoneName: "short",
+    ...dateTimeOptions,
+    timeZoneName: "short"
   }).format(new Date(timestamp));
+}
+
+export function formatLaunchSiteDateTime(timestamp) {
+
+  // get the offset between launch site time zone and UTC time zone
+  const timeStampOffset = timestamp.slice(-6); 
+  const offsetSign = timeStampOffset.slice(0, 1);
+  let launchSiteOffset = timeStampOffset.slice(1, 3) * 60;
+
+  // get the offset between user time zone and UTC time zone
+  const userDate = new Date(timestamp);
+  const UTCTimeZoneOffset = userDate.getTimezoneOffset();
+  if (offsetSign === '-') launchSiteOffset = -Math.abs(launchSiteOffset);
+
+  // add both offsets to user local time
+  const launchSiteDate = userDate.setMinutes(userDate.getMinutes() + UTCTimeZoneOffset + launchSiteOffset);
+
+  return new Intl.DateTimeFormat("en-US", dateTimeOptions).format(new Date(launchSiteDate)) + ` GMT${offsetSign}${Math.abs(launchSiteOffset / 60)}`;
 }

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -24,7 +24,6 @@ export function formatDateTime(timestamp) {
 }
 
 export function formatLaunchSiteDateTime(timestamp) {
-  // timestamp = '2017-06-23T19:10:000Z'
 
   // get the offset between launch site time zone and UTC time zone
   const timeStampOffset = timestamp.slice(-6); 

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -24,11 +24,12 @@ export function formatDateTime(timestamp) {
 }
 
 export function formatLaunchSiteDateTime(timestamp) {
+  // timestamp = '2017-06-23T19:10:000Z'
 
   // get the offset between launch site time zone and UTC time zone
   const timeStampOffset = timestamp.slice(-6); 
   const offsetSign = timeStampOffset.slice(0, 1);
-  let launchSiteOffset = timeStampOffset.slice(1, 3) * 60;
+  let launchSiteOffset = timeStampOffset.slice(1, 3) * 60 + timeStampOffset.slice(-2) * 1;
 
   // get the offset between user time zone and UTC time zone
   const userDate = new Date(timestamp);


### PR DESCRIPTION
The fix for this bug is an additional function that retrieves the time offset from the api data `launch_date_local` and adds it to the user's local time. It lets the user see the launch site local time of launch, as well as a GMT indicator displaying the offset. This works if the date is passed as a local ISO 8601 timestamp (as specified in the API documentation).

Other solutions considered: 
1. Bringing in a third party library. I did not think it was necessary for a single use case, however it could be reconsidered at later stages of development.
2. Hard-coding the IANA standard timezones. Sadly, this data isn't provided by the API, so it would have to be retrieved with the help of the launch site location or ID. 
Something like: 
`switch (launch_site_id) {
  case 'vafb_slc_4e':
    return 'America/Los_Angeles'
    break;
// and so on
}`
Since there are only 6 launch sites currently listed, this could be easily implemented and it offers the benefits of displaying the local time with no hassle, and the standard time zone denomination. 
However hard-coding is not optimal and could lead to bugs in case a new launch site is added, so I decided against implementing this solution